### PR TITLE
Add wc-i18n V2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "4"
   - "5"

--- a/index.js
+++ b/index.js
@@ -113,12 +113,14 @@ var wcI18nV2 = function(file, encoding, callback) {
         text: dom5.getTextContent(script)
       }
     }).filter(function(jsStringObj) {
-      return ~jsStringObj.text.indexOf('WCI18n');
+      return /\bWCI18n\b/.test(jsStringObj.text);
     }).map(function(jsStringObj) {
       return {
         script: jsStringObj.script,
         tree: ast(jsStringObj.text)
       };
+    }).filter(function(treeObj) {
+      return treeObj.tree.callExpression('WCI18n').length > 0;
     }).filter(function(treeObj) {
       return treeObj.tree.callExpression('WCI18n').arguments.length = 1;
     }).map(function(treeObj) {
@@ -130,6 +132,8 @@ var wcI18nV2 = function(file, encoding, callback) {
           translations: translations
         }
       });
+    }).filter(function(promises) {
+      return !!promises;
     });
 
     Promise.all(promises)

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var dom5 = require('dom5');
 var path = require('path');
 var fs = require('fs');
 var q = require('q');
+var ast = require('ast-query');
 var pred = dom5.predicates;
 
 var srcTagFinder = pred.AND(
@@ -17,6 +18,10 @@ var srcTagFinder = pred.AND(
   ),
   pred.hasAttr('locale-dir')
 );
+
+var scriptTagFinder = pred.AND(
+  pred.hasTagName('script')
+)
 
 var slashRegex = /([^/]+$)/;
 var localeRegex = /.*_(\w{2}).json/;
@@ -39,54 +44,115 @@ var fetchJSONContent = function(file) {
   return returnObj;
 };
 
-var getNewContents = function(localePath, componentName, doc, el) {
+var getTranslations = function(localePath, componentName) {
   var dfd = q.defer();
 
   glob(localePath + '/' + componentName + '_' + '*.json', function(err, files) {
-    var srcLocales = files.map(fetchJSONContent);
-    dom5.removeAttribute(el, 'locale-dir');
-    dom5.setAttribute(el, 'src-locales', JSON.stringify(srcLocales.reduce(flattenArray, {})));
-    dfd.resolve(dom5.serialize(doc));
+    var srcLocales = files.map(fetchJSONContent).reduce(flattenArray, {});
+    dfd.resolve(srcLocales);
   });
 
   return dfd.promise;
 };
 
-module.exports = function () {
-  var newline = gutil.linefeed;
-   var buildClosure = function() {
-     return function(file, encoding, callback) {
-      if (file.isNull()) {
-        this.push(file);
-        return callback();        
-      }
+var wcI18nV1 = function(file, encoding, callback) {
+  if (file.isNull()) {
+    this.push(file);
+    return callback();        
+  }
 
-      if (file.isStream()) {
-        this.emit('error', new PluginError(PLUGIN_NAME, PLUGIN_NAME + ': Streaming not supported'));
-        return callback();
-      }
+  if (file.isStream()) {
+    this.emit('error', new PluginError(PLUGIN_NAME, PLUGIN_NAME + ': Streaming not supported'));
+    return callback();
+  }
 
-      if (file.isBuffer()) {
-        var doc = dom5.parseFragment(String(file.contents));
-        var el = dom5.query(doc, srcTagFinder)
-        if (el) {
-          var componentName = dom5.getAttribute(el, 'domain');
-          var locationAttr = dom5.getAttribute(el, 'locale-dir');
-          var localePath = (locationAttr === '[[localeDir()]]' || locationAttr === '{{localeDir()}}') ? path.resolve(file.path, '../locales') : null;
-          if (localePath) {
-            return getNewContents(localePath, componentName, doc, el)
-              .then(function(contents) {
-                file.contents = new Buffer(contents);
-                this.push(file);
-                return callback();
-              }.bind(this));
-          }
+  if (file.isBuffer()) {
+    var doc = dom5.parseFragment(String(file.contents));
+    var el = dom5.query(doc, srcTagFinder)
+    if (el) {
+      var componentName = dom5.getAttribute(el, 'domain');
+      var locationAttr = dom5.getAttribute(el, 'locale-dir');
+      var localePath = (locationAttr === '[[localeDir()]]' || locationAttr === '{{localeDir()}}') ? path.resolve(file.path, '../locales') : null;
+      if (localePath) {
+        return getTranslations(localePath, componentName)
+          .then(function(translations) {
+            dom5.removeAttribute(el, 'locale-dir');
+            dom5.setAttribute(el, 'src-locales', JSON.stringify(translations));
+            return dom5.serialize(doc);
+          })
+          .then(function(contents) {
+            file.contents = new Buffer(contents);
+            this.push(file);
+            return callback();
+          }.bind(this));
+      }
+    }
+  }
+  this.push(file);
+  return callback();
+};
+
+var wcI18nV2 = function(file, encoding, callback) {
+  if (file.isNull()) {
+    this.push(file);
+    return callback();        
+  }
+
+  if (file.isStream()) {
+    this.emit('error', new PluginError(PLUGIN_NAME, PLUGIN_NAME + ': Streaming not supported'));
+    return callback();
+  }
+
+  if (file.isBuffer()) {
+    var doc = dom5.parseFragment(String(file.contents));
+    var scripts = dom5.queryAll(doc, scriptTagFinder);
+    // do stuff
+    var promises = scripts.map(function(script) {
+      return {
+        script: script,
+        text: dom5.getTextContent(script)
+      }
+    }).filter(function(jsStringObj) {
+      return ~jsStringObj.text.indexOf('WCI18n');
+    }).map(function(jsStringObj) {
+      return {
+        script: jsStringObj.script,
+        tree: ast(jsStringObj.text)
+      };
+    }).filter(function(treeObj) {
+      return treeObj.tree.callExpression('WCI18n').arguments.length = 1;
+    }).map(function(treeObj) {
+      var componentName = treeObj.tree.callExpression('WCI18n').arguments.at(0).value();
+      return getTranslations(path.resolve(file.path, '../locales'), componentName).then(function(translations) {
+        return {
+          script: treeObj.script,
+          tree: treeObj.tree,
+          translations: translations
         }
-      }
-      this.push(file);
-      return callback();
-    };
-  };
+      });
+    });
 
-  return through.obj(buildClosure());
+    Promise.all(promises)
+      .then(function(i18nObjArray) {
+        i18nObjArray.forEach(function(i18nObj) {
+          var args = i18nObj.tree.callExpression('WCI18n').arguments;
+          args.push(JSON.stringify(i18nObj.translations));
+          dom5.setTextContent(i18nObj.script, i18nObj.tree.toString());
+        });
+      })
+      .then(function() {
+        return dom5.serialize(doc);
+      })
+      .then(function(contents) {
+        file.contents = new Buffer(contents);
+        this.push(file);
+        return callback();
+      }.bind(this));
+  }
+};
+
+module.exports = function (config) {
+  var version = config && config.version || 1;
+  var handler = version === 2 ? wcI18nV2 : wcI18nV1;
+  return through.obj(handler);
 };

--- a/index.js
+++ b/index.js
@@ -121,10 +121,8 @@ var wcI18nV2 = function(file, encoding, callback) {
       };
     }).filter(function(treeObj) {
       return treeObj.tree.callExpression('WCI18n').length > 0;
-    }).filter(function(treeObj) {
-      return treeObj.tree.callExpression('WCI18n').arguments.length = 1;
     }).map(function(treeObj) {
-      var componentName = treeObj.tree.callExpression('WCI18n').arguments.at(0).value();
+      var componentName = treeObj.tree.callExpression('Polymer').arguments.at(0).key('is').value();
       return getTranslations(path.resolve(file.path, '../locales'), componentName).then(function(translations) {
         return {
           script: treeObj.script,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/jshcrowthe/gulp-wc-i18n#readme",
   "dependencies": {
+    "ast-query": "^2.0.0",
     "dom5": "^1.3.1",
     "glob": "^6.0.1",
     "gulp-util": "^3.0.7",

--- a/test/outFiles/v2-comp.html
+++ b/test/outFiles/v2-comp.html
@@ -10,6 +10,20 @@
   </template>
   <script>Polymer({
     is: 'v2-comp',
-    behaviors: [WCI18n('v2-comp', { 'en': { 'foo': 'What does fubar actually stand for?' } })]
+    behaviors: [WCI18n({ 'en': { 'foo': 'What does fubar actually stand for?' } })]
+});</script>
+</dom-module>
+
+<dom-module id="v2-comp-2">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+  </template>
+  <script>Polymer({
+    is: 'v2-comp-2',
+    behaviors: [WCI18n({ 'en': { 'bar': 'The second part of this is great yeah?' } })]
 });</script>
 </dom-module>

--- a/test/outFiles/v2-comp.html
+++ b/test/outFiles/v2-comp.html
@@ -1,0 +1,15 @@
+<link rel="import" href="../../wc-i18n.html">
+
+<dom-module id="v2-comp">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+  </template>
+  <script>Polymer({
+    is: 'v2-comp',
+    behaviors: [WCI18n('v2-comp', { 'en': { 'foo': 'What does fubar actually stand for?' } })]
+});</script>
+</dom-module>

--- a/test/tests.js
+++ b/test/tests.js
@@ -28,4 +28,17 @@ describe('gulp-wc-i18n', function() {
     }))
     .pipe(assert.end(done));
   });
+
+  it('should properly inject all locale files (if available)', function(done) {
+    var stream = StreamFactory('v2-comp');
+    stream.pipe(wcI18n({
+      version: 2
+    }))
+    .pipe(assert.first(function(d) { 
+      var contents = d.contents.toString().trim();
+      var expected = fs.readFileSync(path.join(__dirname, './outFiles/v2-comp.html'), 'utf8').trim();
+      expect(contents).to.equal(expected);
+    }))
+    .pipe(assert.end(done));
+  });
 });

--- a/test/v2-comp/locales/v2-comp-2_en.json
+++ b/test/v2-comp/locales/v2-comp-2_en.json
@@ -1,0 +1,3 @@
+{
+  "bar": "The second part of this is great yeah?"
+}

--- a/test/v2-comp/locales/v2-comp_en.json
+++ b/test/v2-comp/locales/v2-comp_en.json
@@ -1,0 +1,3 @@
+{
+  "foo": "What does fubar actually stand for?"
+}

--- a/test/v2-comp/v2-comp.html
+++ b/test/v2-comp/v2-comp.html
@@ -12,7 +12,25 @@
     Polymer({
       is: 'v2-comp',
       behaviors: [
-        WCI18n('v2-comp')
+        WCI18n()
+      ]
+    });
+  </script>
+</dom-module>
+
+<dom-module id="v2-comp-2">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+  </template>
+  <script>
+    Polymer({
+      is: 'v2-comp-2',
+      behaviors: [
+        WCI18n()
       ]
     });
   </script>

--- a/test/v2-comp/v2-comp.html
+++ b/test/v2-comp/v2-comp.html
@@ -1,0 +1,19 @@
+<link rel="import" href="../../wc-i18n.html">
+
+<dom-module id="v2-comp">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+  </template>
+  <script>
+    Polymer({
+      is: 'v2-comp',
+      behaviors: [
+        WCI18n('v2-comp')
+      ]
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
This allows people using `v2.0.0` to inject translations for prod time.

## Consumption

This is consumed by passing a config object with the `version` prop set to `2`

_e.g._
```javascript
gulp.task('i18n', function() {
  return gulp.src('path/to/elements/*.html')
    .pipe(wcI18n({
      version: 2
    }))
    .pipe(gulp.dest('.'));
});

```